### PR TITLE
fix: change event schedule

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest",
     "invoke:local": "serverless invoke local -f postLlstQuote",
-    "deploy": "serverless deploy function -f postLlstQuote"
+    "deploy": "serverless deploy"
   },
   "engines": {
     "node": ">=14.15.0"

--- a/src/functions/post-llst-quote/index.ts
+++ b/src/functions/post-llst-quote/index.ts
@@ -14,7 +14,7 @@ const config: ServerlessFunctionConfiguration = {
   events: [
     {
       schedule: {
-        rate: ["rate(1 day)"],
+        rate: ["cron(0 23 * * ? *)"],
       },
     },
   ],


### PR DESCRIPTION
`serverless deploy function` では Amazon EventBridge は更新されなかった。
デプロイのコマンドを `serverless deploy` に変更する。（`serverless deploy function` はテスト用途で本番デプロイに使うべきではない、とドキュメントにも書かれている。 https://www.serverless.com/framework/docs/providers/aws/cli-reference/deploy-function）
ついでに、イベント発行時刻を cron で明示する。